### PR TITLE
Fix: duplicate URL causes validation failure.

### DIFF
--- a/source/resources/valueset-us-core-encounter-type.xml
+++ b/source/resources/valueset-us-core-encounter-type.xml
@@ -35,7 +35,6 @@
 		</telecom>
 	</contact>
 	<description value="The type of encounter: a specific code indicating type of service provided. This value set includes codes from SNOMED CT decending from the concept 308335008 (Patient encounter procedure (procedure)) and from the Current Procedure and Terminology(CPT) designated for Evaluation and Management (99200 – 99607) (subscription to AMA Required)"/>
-	<url value="http://hl7.org/fhir/us/core/ValueSet/us-core-encounter-type"/>
 	<copyright value="This value set includes content from SNOMED CT, which is copyright © 2002+ International Health Terminology Standards Development Organisation (IHTSDO), and distributed by agreement between IHTSDO and HL7. Implementer use of SNOMED CT is not covered by this agreement.  This value set includes content from CPT copyright 2014 American Medical Association. All rights reserved."/>
 	<compose>
     <include>


### PR DESCRIPTION
The URL is already present, this removes the duplicate one.